### PR TITLE
Display clink redux

### DIFF
--- a/flask-server/main.py
+++ b/flask-server/main.py
@@ -308,18 +308,18 @@ def fetch_clinks():
         for clink in all_list:
             for id in clink_ids:
                 if id['clink_id'] == clink.id:
-                    json = {
+                    response_object = {
                         'title': clink['title'],
                         'id': clink.id 
                     }
-                    to_return.append(json)              
+                    to_return.append(response_object)              
         return jsonify(to_return), 200
     else:
         response_object = {
             'status': 'fail',
             'message': 'Invalid JWT. Failed to fetch clinks.'
         }
-        return responce_object, 401
+        return response_object, 401
 
 
 # routing

--- a/react-app/src/components/Common/newbutton.js
+++ b/react-app/src/components/Common/newbutton.js
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
-import { useDispatch } from 'react-redux';
-import { addClink, addBookmark } from '../../features/clink';
+import React, { useEffect, useState } from 'react';
+import { useSelector, useDispatch } from 'react-redux';
+import { fetchClinks, addClink, addBookmark } from '../../features/clink';
 import 'antd/dist/antd.css';
 import '../../index.css';
 import { PlusOutlined } from '@ant-design/icons';
@@ -11,7 +11,9 @@ const { TabPane } = Tabs;
 
 const NewButton = () => {
 
-  const currentToken = localStorage.getItem('currentToken')
+  const currentToken = localStorage.getItem('currentToken');
+  const clinks = useSelector(state => state.clink.clinks);
+  const isCurrentUserFetched = useSelector(state => state.users.isCurrentUserFetched);
 
   const dispatch = useDispatch()
   const [bookmarkForm] = Form.useForm()
@@ -22,6 +24,12 @@ const NewButton = () => {
   const [isLoading, setIsLoading] = useState(false);
   const [form, setForm] = useState('bookmark');
 
+  useEffect(() => {
+    if(isCurrentUserFetched) {
+      dispatch(fetchClinks(currentToken))
+    }
+  }, []);
+
   const showModal = () => {
     setIsVisible(true);
   };
@@ -31,6 +39,8 @@ const NewButton = () => {
     if (!values.description) {
       values.description = ' ';
     }
+    values.toAdd.unshift('All');
+    console.log(values.toAdd);
     dispatch(addBookmark(values.link, values.title, values.description, values.toAdd, addSuccess, addFail))
     bookmarkForm.resetFields()
     setTimeout(() => {
@@ -145,14 +155,14 @@ const NewButton = () => {
                 name="toAdd"
                 rules={[
                   {
-                    required: true
+                    required: false
                   },
                 ]}
               >
-                <Select mode="multiple" defaultValue="All">
-                  <Option value="All">All</Option>
-                  <Option value="clink1">Clink 1</Option>
-                  <Option value="clink2">Clink 2</Option>
+                <Select mode="multiple">
+                  {clinks.map(item => (
+                    <Option value={item.id}>{item.title}</Option>
+                  ))}
                 </Select>
               </Form.Item>
             </Form>

--- a/react-app/src/components/Common/sidebar.js
+++ b/react-app/src/components/Common/sidebar.js
@@ -13,11 +13,14 @@ const Sidebar = () => {
 
   const currentToken = localStorage.getItem('currentToken')
   const clinks = useSelector(state => state.clink.clinks)
+  const isCurrentUserFetched = useSelector(state => state.users.isCurrentUserFetched)
 
   const dispatch = useDispatch()
 
   useEffect(() => {
-    dispatch(fetchClinks(currentToken))
+    if(isCurrentUserFetched){
+      dispatch(fetchClinks(currentToken))
+    }
   }, []);
 
   return (

--- a/react-app/src/components/Common/sidebar.js
+++ b/react-app/src/components/Common/sidebar.js
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
-import axios from 'axios';
-import { useSelector } from 'react-redux';
+import { useSelector, useDispatch } from 'react-redux';
+import { fetchClinks } from '../../features/clink'
 import 'antd/dist/antd.css';
 import '../../index.css';
 import { Layout, Menu } from 'antd';
@@ -11,22 +11,14 @@ const { Sider } = Layout;
 
 const Sidebar = () => {
 
-  const currentUser = useSelector(state => state.users.currentUser)
-  const isAddingClink = useSelector(state => state.clink.isAddingClink)
+  const currentToken = localStorage.getItem('currentToken')
+  const clinks = useSelector(state => state.clink.clinks)
 
-  const [menuItems, setMenuItems] = useState([])
+  const dispatch = useDispatch()
 
   useEffect(() => {
-    axios.get(`http://localhost:5000/apis/fetch-clinks`, {
-      headers: {'id': currentUser}
-    }).then(
-      (response) => {
-        const allItems = response.data;
-        console.log(allItems)
-        setMenuItems(allItems);
-    });
-  }, [isAddingClink]);
-
+    dispatch(fetchClinks(currentToken))
+  }, []);
 
   return (
     <Sider className="sidebar">
@@ -39,7 +31,7 @@ const Sidebar = () => {
           All
         </Menu.Item>
         
-        {menuItems.map(item => (
+        {clinks.map(item => (
           <Menu.Item key={item.id}>{item.title}</Menu.Item>
         ))}
       </Menu>

--- a/react-app/src/components/Common/sidebar.js
+++ b/react-app/src/components/Common/sidebar.js
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { fetchClinks } from '../../features/clink'
 import 'antd/dist/antd.css';

--- a/react-app/src/components/Common/sidebar.js
+++ b/react-app/src/components/Common/sidebar.js
@@ -11,15 +11,15 @@ const { Sider } = Layout;
 
 const Sidebar = () => {
 
-  const currentToken = localStorage.getItem('currentToken')
-  const clinks = useSelector(state => state.clink.clinks)
-  const isCurrentUserFetched = useSelector(state => state.users.isCurrentUserFetched)
+  const currentToken = localStorage.getItem('currentToken');
+  const clinks = useSelector(state => state.clink.clinks);
+  const isCurrentUserFetched = useSelector(state => state.users.isCurrentUserFetched);
 
-  const dispatch = useDispatch()
+  const dispatch = useDispatch();
 
   useEffect(() => {
-    if(isCurrentUserFetched){
-      dispatch(fetchClinks(currentToken))
+    if (isCurrentUserFetched) {
+      dispatch(fetchClinks(currentToken));
     }
   }, []);
 

--- a/react-app/src/features/apis.js
+++ b/react-app/src/features/apis.js
@@ -7,6 +7,7 @@ const LOGOUT_URL = `${BASE_URL}/logout`;
 const GET_CURR_USER_URL = `${BASE_URL}/get-curr-user`;
 const ADD_CLINK_URL = `${BASE_URL}/add-clink`;
 const ADD_BOOKMARK_URL = `${BASE_URL}/add-bookmark`;
+const FETCH_CLINK_URL = `${BASE_URL}/fetch-clinks`;
 
 const signUp = (email, username, password) => axios.post(SIGNUP_URL, {
   email: email,
@@ -30,7 +31,7 @@ const checkUser = (token) => axios.get(GET_CURR_USER_URL, {
 
 const addClink = (title, token) => axios.post(ADD_CLINK_URL, {
   title: title,
-  token: token
+  Authorization: token
 });
 
 const addBookmark = (link, title, description, clink) => axios.post(ADD_BOOKMARK_URL, {
@@ -40,6 +41,10 @@ const addBookmark = (link, title, description, clink) => axios.post(ADD_BOOKMARK
   clink: clink
 });
 
+const fetchClinks = (token) => axios.get(FETCH_CLINK_URL, {
+  headers: {'Authorization': token}
+});
+
 export default {
-  signUp, login, logout, checkUser, addClink, addBookmark
+  signUp, login, logout, checkUser, addClink, addBookmark, fetchClinks
 } 	

--- a/react-app/src/features/apis.js
+++ b/react-app/src/features/apis.js
@@ -7,7 +7,7 @@ const LOGOUT_URL = `${BASE_URL}/logout`;
 const GET_CURR_USER_URL = `${BASE_URL}/get-curr-user`;
 const ADD_CLINK_URL = `${BASE_URL}/add-clink`;
 const ADD_BOOKMARK_URL = `${BASE_URL}/add-bookmark`;
-const FETCH_CLINK_URL = `${BASE_URL}/fetch-clinks`;
+const FETCH_CLINKS_URL = `${BASE_URL}/fetch-clinks`;
 
 const signUp = (email, username, password) => axios.post(SIGNUP_URL, {
   email: email,
@@ -41,7 +41,7 @@ const addBookmark = (link, title, description, clink) => axios.post(ADD_BOOKMARK
   clink: clink
 });
 
-const fetchClinks = (token) => axios.get(FETCH_CLINK_URL, {
+const fetchClinks = (token) => axios.get(FETCH_CLINKS_URL, {
   headers: {'Authorization': token}
 });
 

--- a/react-app/src/features/clink.js
+++ b/react-app/src/features/clink.js
@@ -3,7 +3,9 @@ import apis from './apis';
 
 const initialState = {
   isAddingClink: false,
-
+  isAddingBookmark: false,
+  isFetchingClinks: false,
+  clinks: []
 };
 
 const clinkSlice = createSlice({
@@ -13,8 +15,9 @@ const clinkSlice = createSlice({
     addClinkStart(state){
       state.isAddingClink = true;
     },
-    addClinkSucceed(state){
+    addClinkSucceed(state, action){
       state.isAddingClink = false;
+      state.clinks = [...state.clinks, action.payload]
       delete state.clinkError;
     },
     addClinkFailed(state, action){
@@ -31,19 +34,34 @@ const clinkSlice = createSlice({
     addBookmarkFailed(state, action){
       state.isAddingBookmark = false;
       state.bookmarkError = action.payload;
-    }     
+    },
+    fetchClinksStart(state){
+      state.isFetchingClink = true;
+    },
+    fetchClinksSucceed(state, action){
+      state.isFetchingClink = false;
+      state.clinks = action.payload
+      delete state.clinkError;
+    },
+    fetchClinksFailed(state, action){
+      state.isFetchingClink = false;
+      state.clinkError = action.payload;
+    },     
   },
 });
 
 export const {
-  addClinkStart, addClinkSucceed, addClinkFailed, addBookmarkStart, addBookmarkSucceed, addBookmarkFailed
+  addClinkStart, addClinkSucceed, addClinkFailed, 
+  addBookmarkStart, addBookmarkSucceed, addBookmarkFailed,
+  fetchClinksStart, fetchClinksSucceed, fetchClinksFailed,
 } = clinkSlice.actions;
 
 export const addClink = (title, token, callbackSucceed, callbackFailed) => async dispatch => {
   try {
     dispatch(addClinkStart())
-    await apis.addClink(title, token) // maybe save value as an variable
-    dispatch(addClinkSucceed())
+    const response = await apis.addClink(title, token) 
+    console.log(response)
+    dispatch(addClinkSucceed(response.data))
     callbackSucceed()
   } catch (err) {
     dispatch(addClinkFailed(err.response.data.message))
@@ -60,6 +78,16 @@ export const addBookmark = (link, title, description, clink, callbackSucceed, ca
   } catch (err) {
     dispatch(addBookmarkFailed(err.response.data.message))
     callbackFailed(err.response.data.message)
+  }
+}
+
+export const fetchClinks = (token) => async dispatch => {
+  try {
+    dispatch(fetchClinksStart())
+    const response = await apis.fetchClinks(token)
+    dispatch(fetchClinksSucceed(response.data))
+  } catch (err) {
+    dispatch(fetchClinksFailed(err.response.data.message))
   }
 }
 

--- a/react-app/src/features/clink.js
+++ b/react-app/src/features/clink.js
@@ -60,7 +60,6 @@ export const addClink = (title, token, callbackSucceed, callbackFailed) => async
   try {
     dispatch(addClinkStart())
     const response = await apis.addClink(title, token) 
-    console.log(response)
     dispatch(addClinkSucceed(response.data))
     callbackSucceed()
   } catch (err) {

--- a/react-app/src/features/clink.js
+++ b/react-app/src/features/clink.js
@@ -17,7 +17,7 @@ const clinkSlice = createSlice({
     },
     addClinkSucceed(state, action){
       state.isAddingClink = false;
-      state.clinks = [...state.clinks, action.payload]
+      state.clinks = [action.payload, ...state.clinks]
       delete state.clinkError;
     },
     addClinkFailed(state, action){

--- a/react-app/src/features/clink.js
+++ b/react-app/src/features/clink.js
@@ -36,15 +36,15 @@ const clinkSlice = createSlice({
       state.bookmarkError = action.payload;
     },
     fetchClinksStart(state){
-      state.isFetchingClink = true;
+      state.isFetchingClinks = true;
     },
     fetchClinksSucceed(state, action){
-      state.isFetchingClink = false;
+      state.isFetchingClinks = false;
       state.clinks = action.payload
       delete state.clinkError;
     },
     fetchClinksFailed(state, action){
-      state.isFetchingClink = false;
+      state.isFetchingClinks = false;
       state.clinkError = action.payload;
     },     
   },

--- a/react-app/src/features/users.js
+++ b/react-app/src/features/users.js
@@ -52,6 +52,7 @@ const usersSlice = createSlice({
       state.loginError = action.payload;
     },
     logout(state) {
+      state.isCurrentUserFetched = false;
       localStorage.removeItem('currentToken');
       delete state.currentUser;
     },


### PR DESCRIPTION
## Note
Branch is called display-clinkp-redux (typo) branches off display-clink-1.5.

## Change Log
Implemented clinkReducer to hold all of an user's clinks. Fetches once on a page with a sidebar, then individual clinks added after that are added to the store instead of fetched. Added clinks are still added database, so next fetch call will include them.

## Next Steps
- Order clinks by creation (or some property) because currently when a clink is added it is put on top (as it's prepended to the store's clinks array) but when fetched that same clink might be in another position based on query sequence, might cause confusion when an user looks for a clink.