### PR TITLE
Logout clear redux

### DIFF
--- a/react-app/src/components/Common/newbutton.js
+++ b/react-app/src/components/Common/newbutton.js
@@ -118,7 +118,7 @@ const NewButton = () => {
                   },
                 ]}
               >
-                <Input place defaultValue="https://www." />
+                <Input defaultValue="https://www." />
               </Form.Item>
               <Form.Item
                 label="Title"

--- a/react-app/src/components/Common/topbar.js
+++ b/react-app/src/components/Common/topbar.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useSelector, useDispatch } from 'react-redux';
 import { logOut } from '../../features/users';
+import { clearClinksAndBookmarks } from '../../features/clink';
 import 'antd/dist/antd.css';
 import '../../index.css';
 import { Layout, Input, Dropdown, Menu } from 'antd';
@@ -19,6 +20,7 @@ const Topbar = () => {
 
   const logout = () => {
     dispatch(logOut(currentToken))
+    dispatch(clearClinksAndBookmarks())
   };
 
   const menu = (

--- a/react-app/src/components/Dashboard/index.js
+++ b/react-app/src/components/Dashboard/index.js
@@ -42,7 +42,7 @@ const Dashboard = () => {
       <Layout className="site-layout">
         <Topbar />
         <Content style={{ position: 'relative', margin: '24px 16px 0', overflow: 'auto', height: '65vh' }}>
-          <div className="site-layout-background" style={{ padding: '24px' }}>
+          <div className="site-layout-background" style={{ padding: '24px', minHeight: '65vh' }}>
           <Card />
           </div>
         </Content>

--- a/react-app/src/features/clink.js
+++ b/react-app/src/features/clink.js
@@ -19,7 +19,7 @@ const clinkSlice = createSlice({
     },
     addClinkSucceed(state, action){
       state.isAddingClink = false;
-      state.clinks = [action.payload, ...state.clinks]
+      state.clinks = [action.payload, ...state.clinks];
       delete state.clinkError;
     },
     addClinkFailed(state, action){
@@ -31,7 +31,7 @@ const clinkSlice = createSlice({
     },
     addBookmarkSucceed(state, action){
       state.isAddingBookmark = false;
-      state.bookmarks = [action.payload, ...state.bookmarks]
+      state.bookmarks = [action.payload, ...state.bookmarks];
       delete state.clinkError;
     },
     addBookmarkFailed(state, action){
@@ -55,13 +55,19 @@ const clinkSlice = createSlice({
     },
     fetchBookmarksSucceed(state, action){
       state.isFetchingBookmarks = false;
-      state.bookmarks = action.payload
+      state.bookmarks = action.payload;
       delete state.bookmarkError;
     },
     fetchBookmarksFailed(state, action){
       state.isFetchingBookmarks = false;
       state.bookmarkError = action.payload;
-    }     
+    },
+    clearClinks(state){
+      state.clinks = [];
+    },
+    clearBookmarks(state){
+      state.bookmarks = [];
+    }    
   },
 });
 
@@ -69,7 +75,8 @@ export const {
   addClinkStart, addClinkSucceed, addClinkFailed, 
   addBookmarkStart, addBookmarkSucceed, addBookmarkFailed,
   fetchClinksStart, fetchClinksSucceed, fetchClinksFailed,
-  fetchBookmarksStart, fetchBookmarksSucceed, fetchBookmarksFailed
+  fetchBookmarksStart, fetchBookmarksSucceed, fetchBookmarksFailed,
+  clearClinks, clearBookmarks
 } = clinkSlice.actions;
 
 export const addClink = (title, token, callbackSucceed, callbackFailed) => async dispatch => {
@@ -116,6 +123,11 @@ export const fetchBookmarks = (token, clinkId) => async dispatch => {
   } catch (err) {
     dispatch(fetchBookmarksFailed(err.response.data.message))
   }
+}
+
+export const clearClinksAndBookmarks = () => async dispatch => {
+  dispatch(clearClinks())
+  dispatch(clearBookmarks())
 }
 
 export default clinkSlice.reducer;


### PR DESCRIPTION
## Change Log
When an user logs out, we clear the redux store of clinks and bookmarks saved. So if a new user immediately logs in it doesn't show the old users clinks for a moment before updating to the correct user. Also extended white background to always fill up the entire space.

## Screenshots
| Before        | After         | 
| ------------- |:-------------:| 
| ![image](https://user-images.githubusercontent.com/65906220/87793044-b4697c80-c812-11ea-8766-cc91cc94e20c.png)| ![image](https://user-images.githubusercontent.com/65906220/87792974-9ef45280-c812-11ea-9bd6-4ccf538568ba.png) | 

## Next Steps
To help database structure we could potential create a read-access/write-access API that checks if an user can just read or can also edit an clink, instead relying heavily on the initial fetching of clinks and bookmarks to provide enough information. 