### PR TITLE
Database type

### DIFF
--- a/flask-server/main.py
+++ b/flask-server/main.py
@@ -248,15 +248,15 @@ def add_bookmark():
             'description': request.json['description'],
             'deleted': False,
             'created': datetime.datetime.now(timezone.utc),
-            'creator': str(resp_token)
+            'creator': int(resp_token)
         })
         datastore_client.put(entity)
 
         for clink in request.json['clink']:
             map_entity = datastore.Entity(key=datastore_client.key('bookmark_clink_map'));
             map_entity.update({
-                'clink_id': clink,
-                'bookmark_id': entity.id
+                'clink_id': int(clink),
+                'bookmark_id': int(entity.id)
             })
             datastore_client.put(map_entity)
 
@@ -307,8 +307,8 @@ def add_clink():
         read_entity = datastore.Entity(key=datastore_client.key('user_read_map'))
 
         mapping = {
-            'clink_id': clink_entity.id,
-            'user_id': str(resp_token)
+            'clink_id': int(clink_entity.id),
+            'user_id': int(resp_token)
         }
             
         write_entity.update(mapping)
@@ -333,7 +333,7 @@ def fetch_clinks():
     resp_token = decode_auth_token(request.headers.get('Authorization'))
 
     if is_valid_instance(resp_token):
-        clink_ids = list(datastore_client.query(kind='user_read_map').add_filter('user_id', '=', str(resp_token)).fetch())
+        clink_ids = list(datastore_client.query(kind='user_read_map').add_filter('user_id', '=', int(resp_token)).fetch())
         all_query = datastore_client.query(kind='clink').add_filter('deleted', '=', False)
         all_query.order = ['created']
         all_list = list(all_query.fetch())
@@ -361,7 +361,7 @@ def fetch_write_clinks():
     resp_token = decode_auth_token(request.headers.get('Authorization'))
 
     if is_valid_instance(resp_token):
-        clink_ids = list(datastore_client.query(kind='user_write_map').add_filter('user_id', '=', str(resp_token)).fetch())
+        clink_ids = list(datastore_client.query(kind='user_write_map').add_filter('user_id', '=', int(resp_token)).fetch())
         all_query = datastore_client.query(kind='clink').add_filter('deleted', '=', False)
         all_query.order = ['created']
         all_list = list(all_query.fetch())
@@ -389,7 +389,7 @@ def fetch_bookmarks(clink_id):
     resp_token = decode_auth_token(request.headers.get('Authorization'))
     
     if is_valid_instance(resp_token):
-        bookmark_query = datastore_client.query(kind='bookmark').add_filter('creator', '=', str(resp_token)).add_filter('deleted', '=', False)
+        bookmark_query = datastore_client.query(kind='bookmark').add_filter('creator', '=', int(resp_token)).add_filter('deleted', '=', False)
         bookmark_query.order = ['created']
         all_list = list(bookmark_query.fetch())
         if clink_id == 'All':


### PR DESCRIPTION
## Change Log
- In APIs putting entities into database, explicitly cast all id properties to integer. Also, casts query filters to integers as safe guard.

## Next Steps
- Manually update or change property type of older entities as it will cause fetch issues as some of their id properties are still strings.